### PR TITLE
feat: 新增 OpenAI Embeddings 协议支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Lens 对外提供常见 LLM API 路径：
 | ---------------------------- | ---------------------------------------------- |
 | OpenAI Chat Completions      | `/v1/chat/completions`                         |
 | OpenAI Responses             | `/v1/responses`                                |
+| OpenAI Embeddings            | `/v1/embeddings`                               |
 | Anthropic Messages           | `/v1/messages`                                 |
 | OpenAI Models                | `/v1/models`                                   |
 | Gemini generateContent       | `/v1beta/models/{model}:generateContent`       |

--- a/README_EN.md
+++ b/README_EN.md
@@ -40,6 +40,7 @@ Lens exposes common LLM API routes:
 | ---------------------------- | ---------------------------------------------- |
 | OpenAI Chat Completions      | `/v1/chat/completions`                         |
 | OpenAI Responses             | `/v1/responses`                                |
+| OpenAI Embeddings            | `/v1/embeddings`                               |
 | Anthropic Messages           | `/v1/messages`                                 |
 | OpenAI Models                | `/v1/models`                                   |
 | Gemini generateContent       | `/v1beta/models/{model}:generateContent`       |

--- a/lens_api/api/routes/proxy.py
+++ b/lens_api/api/routes/proxy.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 def register(app: FastAPI, service_module) -> None:
     app.add_api_route("/v1/chat/completions", service_module.proxy_openai_chat, methods=["POST"])
     app.add_api_route("/v1/responses", service_module.proxy_openai_responses, methods=["POST"])
+    app.add_api_route("/v1/embeddings", service_module.proxy_openai_embeddings, methods=["POST"])
     app.add_api_route("/v1/messages", service_module.proxy_anthropic_messages, methods=["POST"])
     app.add_api_route("/v1/models", service_module.list_gateway_models, methods=["GET"])
     app.add_api_route(

--- a/lens_api/gateway/service.py
+++ b/lens_api/gateway/service.py
@@ -1193,6 +1193,19 @@ async def proxy_anthropic_messages(
     return await _proxy_protocol(ProtocolKind.ANTHROPIC, body, gateway_key)
 
 
+async def proxy_openai_embeddings(
+    request: Request, gateway_key: GatewayApiKey = Depends(get_current_gateway_key)
+):
+    body = await request.json()
+    if not isinstance(body, dict):
+        raise HTTPException(
+            status_code=400,
+            detail="Embeddings request body must be a JSON object",
+        )
+    body.pop("stream", None)
+    return await _proxy_protocol(ProtocolKind.OPENAI_EMBEDDING, body, gateway_key)
+
+
 async def list_gateway_models(
     gateway_key: GatewayApiKey = Depends(get_current_gateway_key),
 ) -> dict[str, Any]:
@@ -1203,7 +1216,11 @@ async def list_gateway_models(
             for group in groups
             if group.name.strip()
             and group.protocol
-            in {ProtocolKind.OPENAI_CHAT, ProtocolKind.OPENAI_RESPONSES}
+            in {
+                ProtocolKind.OPENAI_CHAT,
+                ProtocolKind.OPENAI_RESPONSES,
+                ProtocolKind.OPENAI_EMBEDDING,
+            }
             and _gateway_key_allows_model(gateway_key, group.name)
         }
     )
@@ -1356,6 +1373,8 @@ async def _proxy_protocol(
                         protocol, body, target.model_name
                     )
                 upstream_body = _apply_param_override(channel, upstream_body)
+                if protocol == ProtocolKind.OPENAI_EMBEDDING:
+                    upstream_body.pop("stream", None)
                 await _update_request_log(
                     request_log_id,
                     protocol=protocol,
@@ -1795,6 +1814,11 @@ def _model_test_body(protocol: ProtocolKind, model_name: str, prompt: str) -> di
             "max_output_tokens": 64,
             "stream": False,
         }
+    if protocol == ProtocolKind.OPENAI_EMBEDDING:
+        return {
+            "model": model_name,
+            "input": text,
+        }
     if protocol == ProtocolKind.ANTHROPIC:
         return {
             "model": model_name,
@@ -1925,6 +1949,20 @@ def _extract_model_test_text(protocol: ProtocolKind, payload: dict[str, Any]) ->
                         if isinstance(text, str) and text.strip():
                             parts.append(text.strip())
             return "\n".join(parts)
+        return ""
+
+    if protocol == ProtocolKind.OPENAI_EMBEDDING:
+        data = payload.get("data")
+        if not isinstance(data, list):
+            return ""
+        for item in data:
+            if not isinstance(item, dict):
+                continue
+            vector = item.get("embedding")
+            if isinstance(vector, list):
+                return f"<vector dim={len(vector)}>"
+            if isinstance(vector, str) and vector:
+                return f"<vector base64 len={len(vector)}>"
         return ""
 
     if protocol == ProtocolKind.ANTHROPIC:
@@ -2070,7 +2108,11 @@ def _model_list_request(channel: ChannelConfig) -> dict[str, Any]:
     api_key = resolve_channel_api_key(channel)
     headers = dict(channel.headers)
 
-    if channel.protocol in {ProtocolKind.OPENAI_CHAT, ProtocolKind.OPENAI_RESPONSES}:
+    if channel.protocol in {
+        ProtocolKind.OPENAI_CHAT,
+        ProtocolKind.OPENAI_RESPONSES,
+        ProtocolKind.OPENAI_EMBEDDING,
+    }:
         return {
             "method": "GET",
             "url": resolve_channel_model_list_url(channel),
@@ -2876,6 +2918,16 @@ def _openai_cached_tokens(usage: Mapping[str, Any], detail_key: str) -> int:
 def _extract_stream_usage(
     protocol: ProtocolKind, raw_content: str | None
 ) -> dict[str, int | str | None]:
+    if protocol == ProtocolKind.OPENAI_EMBEDDING:
+        return {
+            "resolved_model": None,
+            "input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "cache_write_input_tokens": 0,
+            "output_tokens": 0,
+            "total_tokens": 0,
+        }
+
     if not raw_content:
         return {
             "resolved_model": None,
@@ -3052,6 +3104,17 @@ def _extract_usage_from_payload(
             "output_tokens": _usage_int(usage, "output_tokens"),
             "total_tokens": _usage_int(usage, "total_tokens"),
         }
+    if protocol == ProtocolKind.OPENAI_EMBEDDING:
+        usage = _usage_mapping(payload.get("usage"))
+        input_tokens = _usage_int(usage, "prompt_tokens")
+        return {
+            "resolved_model": payload.get("model"),
+            "input_tokens": input_tokens,
+            "cache_read_input_tokens": 0,
+            "cache_write_input_tokens": 0,
+            "output_tokens": 0,
+            "total_tokens": _usage_int(usage, "total_tokens"),
+        }
     if protocol == ProtocolKind.ANTHROPIC:
         if payload.get("type") == "message_start":
             message = _usage_mapping(payload.get("message"))
@@ -3143,6 +3206,18 @@ def _extract_response_usage(
             "cache_read_input_tokens": min(cache_read_input_tokens, input_tokens),
             "cache_write_input_tokens": 0,
             "output_tokens": _usage_int(usage, "output_tokens"),
+            "total_tokens": _usage_int(usage, "total_tokens"),
+        }
+
+    if protocol == ProtocolKind.OPENAI_EMBEDDING:
+        usage = _usage_mapping(payload.get("usage"))
+        input_tokens = _usage_int(usage, "prompt_tokens")
+        return {
+            "resolved_model": payload.get("model"),
+            "input_tokens": input_tokens,
+            "cache_read_input_tokens": 0,
+            "cache_write_input_tokens": 0,
+            "output_tokens": 0,
             "total_tokens": _usage_int(usage, "total_tokens"),
         }
 

--- a/lens_api/gateway/upstreams.py
+++ b/lens_api/gateway/upstreams.py
@@ -55,6 +55,19 @@ def build_upstream_request(
             proxy_url=proxy_url,
         )
 
+    if channel.protocol == ProtocolKind.OPENAI_EMBEDDING:
+        return UpstreamRequest(
+            method="POST",
+            url=target_url,
+            headers={
+                "authorization": f"Bearer {api_key}",
+                "content-type": "application/json",
+                **channel.headers,
+            },
+            json_body=dict(body),
+            proxy_url=proxy_url,
+        )
+
     if channel.protocol == ProtocolKind.ANTHROPIC:
         return UpstreamRequest(
             method="POST",
@@ -94,6 +107,7 @@ def protocol_for_path(path: str) -> ProtocolKind:
     mapping = {
         "/v1/chat/completions": ProtocolKind.OPENAI_CHAT,
         "/v1/responses": ProtocolKind.OPENAI_RESPONSES,
+        "/v1/embeddings": ProtocolKind.OPENAI_EMBEDDING,
         "/v1/messages": ProtocolKind.ANTHROPIC,
         "/v1beta/models": ProtocolKind.GEMINI,
     }
@@ -113,6 +127,8 @@ def _protocol_request_url(channel: ChannelConfig, body: dict[str, Any]) -> str:
         return f"{protocol_base}/chat/completions"
     if channel.protocol == ProtocolKind.OPENAI_RESPONSES:
         return f"{protocol_base}/responses"
+    if channel.protocol == ProtocolKind.OPENAI_EMBEDDING:
+        return f"{protocol_base}/embeddings"
     if channel.protocol == ProtocolKind.ANTHROPIC:
         return f"{protocol_base}/messages"
     raise HTTPException(status_code=500, detail=f"Unsupported protocol={channel.protocol.value}")
@@ -126,7 +142,12 @@ def _protocol_base_url(channel: ChannelConfig) -> str:
     root = _resolve_base_url(channel)
     if _is_bigmodel_openai_chat_prefix(root, channel.protocol):
         return root
-    if channel.protocol in {ProtocolKind.OPENAI_CHAT, ProtocolKind.OPENAI_RESPONSES, ProtocolKind.ANTHROPIC}:
+    if channel.protocol in {
+        ProtocolKind.OPENAI_CHAT,
+        ProtocolKind.OPENAI_RESPONSES,
+        ProtocolKind.OPENAI_EMBEDDING,
+        ProtocolKind.ANTHROPIC,
+    }:
         return f"{root}/v1"
     if channel.protocol == ProtocolKind.GEMINI:
         return f"{root}/v1beta"

--- a/lens_api/models.py
+++ b/lens_api/models.py
@@ -24,6 +24,7 @@ def normalize_base_url(value: Any) -> Any:
 class ProtocolKind(str, Enum):
     OPENAI_CHAT = "openai_chat"
     OPENAI_RESPONSES = "openai_responses"
+    OPENAI_EMBEDDING = "openai_embedding"
     ANTHROPIC = "anthropic"
     GEMINI = "gemini"
 

--- a/ui/src/components/screens/channels-screen.tsx
+++ b/ui/src/components/screens/channels-screen.tsx
@@ -52,6 +52,7 @@ import { ToolbarSearchInput } from '@/components/ui/toolbar-search-input'
 const protocolOptions: Array<{ value: ProtocolKind; label: string }> = [
   { value: 'openai_chat', label: 'OpenAI Chat' },
   { value: 'openai_responses', label: 'OpenAI Responses' },
+  { value: 'openai_embedding', label: 'OpenAI Embedding' },
   { value: 'anthropic', label: 'Anthropic' },
   { value: 'gemini', label: 'Gemini' },
 ]
@@ -164,6 +165,8 @@ function compactProtocolLabel(protocol: ProtocolKind) {
       return 'chat'
     case 'openai_responses':
       return 'responses'
+    case 'openai_embedding':
+      return 'embeddings'
     case 'anthropic':
       return 'anthropic'
     case 'gemini':
@@ -291,6 +294,8 @@ function protocolBadgeClassName(protocol: ProtocolKind) {
       return 'border-transparent bg-sky-500/10 text-sky-700'
     case 'openai_responses':
       return 'border-transparent bg-indigo-500/10 text-indigo-700'
+    case 'openai_embedding':
+      return 'border-transparent bg-cyan-500/10 text-cyan-700'
     case 'anthropic':
       return 'border-transparent bg-amber-500/10 text-amber-700'
     case 'gemini':

--- a/ui/src/components/screens/groups-screen.tsx
+++ b/ui/src/components/screens/groups-screen.tsx
@@ -97,7 +97,7 @@ const MODEL_SERIES_PRESETS = [
     zh: 'OpenAI',
     en: 'OpenAI',
     sampleModel: 'gpt-5.4',
-    prefixes: ['gpt-', 'o1', 'o3', 'o4', 'chatgpt', 'openai'],
+    prefixes: ['gpt-', 'o1', 'o3', 'o4', 'chatgpt', 'openai', 'text-embedding'],
   },
   {
     key: 'claude',
@@ -242,6 +242,7 @@ const strategyOptions: Array<{ value: RoutingStrategy; zh: string; en: string }>
 const protocolLabels: Record<ProtocolKind, { zh: string; en: string }> = {
   openai_chat: { zh: 'OpenAI Chat', en: 'OpenAI Chat' },
   openai_responses: { zh: 'OpenAI Responses', en: 'OpenAI Responses' },
+  openai_embedding: { zh: 'OpenAI Embedding', en: 'OpenAI Embedding' },
   anthropic: { zh: 'Anthropic', en: 'Anthropic' },
   gemini: { zh: 'Gemini', en: 'Gemini' },
 }
@@ -273,6 +274,8 @@ function protocolBadgeClassName(protocol: ProtocolKind) {
       return 'border-transparent bg-sky-500/10 text-sky-700'
     case 'openai_responses':
       return 'border-transparent bg-indigo-500/10 text-indigo-700'
+    case 'openai_embedding':
+      return 'border-transparent bg-cyan-500/10 text-cyan-700'
     case 'anthropic':
       return 'border-transparent bg-amber-500/10 text-amber-700'
     case 'gemini':

--- a/ui/src/components/screens/requests-screen.tsx
+++ b/ui/src/components/screens/requests-screen.tsx
@@ -67,7 +67,7 @@ const MODEL_SERIES_PRESETS = [
     zh: 'OpenAI',
     en: 'OpenAI',
     sampleModel: 'gpt-5.4',
-    prefixes: ['gpt-', 'o1', 'o3', 'o4', 'chatgpt', 'openai'],
+    prefixes: ['gpt-', 'o1', 'o3', 'o4', 'chatgpt', 'openai', 'text-embedding'],
   },
   {
     key: 'claude',
@@ -330,6 +330,7 @@ function ProtocolBadge({ protocol }: { protocol: RequestLogItem['protocol'] }) {
   const labelMap = {
     openai_chat: 'chat',
     openai_responses: 'responses',
+    openai_embedding: 'embeddings',
     anthropic: 'anthropic',
     gemini: 'gemini',
   } as const
@@ -1318,6 +1319,7 @@ export function RequestsScreen() {
                       <NativeSelectOption value="all">{locale === 'zh-CN' ? '全部协议' : 'All protocols'}</NativeSelectOption>
                       <NativeSelectOption value="openai_chat">OpenAI Chat</NativeSelectOption>
                       <NativeSelectOption value="openai_responses">OpenAI Responses</NativeSelectOption>
+                      <NativeSelectOption value="openai_embedding">OpenAI Embedding</NativeSelectOption>
                       <NativeSelectOption value="anthropic">Anthropic</NativeSelectOption>
                       <NativeSelectOption value="gemini">Gemini</NativeSelectOption>
                     </NativeSelect>

--- a/ui/src/components/settings/gateway-api-key-manager.tsx
+++ b/ui/src/components/settings/gateway-api-key-manager.tsx
@@ -88,6 +88,7 @@ const EMPTY_FORM: GatewayApiKeyForm = {
 const PROTOCOL_LABELS: Record<ProtocolKind, [string, string]> = {
   openai_chat: ["OpenAI Chat", "OpenAI Chat"],
   openai_responses: ["OpenAI Responses", "OpenAI Responses"],
+  openai_embedding: ["OpenAI Embedding", "OpenAI Embedding"],
   anthropic: ["Anthropic", "Anthropic"],
   gemini: ["Gemini", "Gemini"],
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,4 +1,4 @@
-export type ProtocolKind = 'openai_chat' | 'openai_responses' | 'anthropic' | 'gemini'
+export type ProtocolKind = 'openai_chat' | 'openai_responses' | 'openai_embedding' | 'anthropic' | 'gemini'
 
 export type RoutingStrategy = 'round_robin' | 'failover'
 export type ModelGroupSyncFilterMode = '' | 'contains' | 'regex'

--- a/ui/src/lib/i18n.tsx
+++ b/ui/src/lib/i18n.tsx
@@ -30,7 +30,7 @@ const messages: Record<Locale, Copy> = {
   'zh-CN': {
     appName: '',
     loginTitle: '统一管理渠道、模型组与系统配置',
-    loginSubtitle: 'OpenAI Chat / OpenAI Responses / Anthropic / Gemini',
+    loginSubtitle: 'OpenAI Chat / OpenAI Responses / OpenAI Embedding / Anthropic / Gemini',
     username: '用户名',
     password: '密码',
     signIn: '登录',
@@ -51,7 +51,7 @@ const messages: Record<Locale, Copy> = {
   'en-US': {
     appName: '',
     loginTitle: 'Manage channels, model groups, and system settings',
-    loginSubtitle: 'OpenAI Chat / OpenAI Responses / Anthropic / Gemini',
+    loginSubtitle: 'OpenAI Chat / OpenAI Responses / OpenAI Embedding / Anthropic / Gemini',
     username: 'Username',
     password: 'Password',
     signIn: 'Sign in',

--- a/ui/src/lib/model-icons.tsx
+++ b/ui/src/lib/model-icons.tsx
@@ -18,7 +18,7 @@ function joinClassNames(...values: Array<string | undefined>) {
 }
 
 const BRAND_ICONS: BrandIconDefinition[] = [
-  { prefixes: ['gpt-', 'o1', 'o3', 'o4', 'chatgpt', 'openai'], src: '/brand-icons/gpt.svg', imageClassName: 'scale-[0.94]', invertInDark: true },
+  { prefixes: ['gpt-', 'o1', 'o3', 'o4', 'chatgpt', 'openai', 'text-embedding'], src: '/brand-icons/gpt.svg', imageClassName: 'scale-[0.94]', invertInDark: true },
   { prefixes: ['claude', 'anthropic'], src: '/brand-icons/claude.svg', imageClassName: 'scale-[0.96]', invertInDark: true },
   { prefixes: ['gemini', 'gemma', 'google'], src: '/brand-icons/gemini.svg', imageClassName: 'scale-[0.94]' },
   { prefixes: ['deepseek'], src: '/brand-icons/deepseek.svg', imageClassName: 'scale-[0.94]' },


### PR DESCRIPTION
## Summary

- 新增 `ProtocolKind.OPENAI_EMBEDDING` 协议，注册对外入口 `POST /v1/embeddings`
- 后端补全上游 URL 构造、模型测试、token 用量解析以及 base64 响应展示
- 前端协议下拉、徽标、筛选项、品牌图标全量适配 `openai_embedding`
- 双语 README 协议路径表新增一行 `/v1/embeddings`，其余说明留待按项目风格补充

注：Embeddings 仅参与同协议直连转发，不接入跨协议转换链路。

## Test plan

- [x] 在已配置的 OpenAI Embeddings 渠道上调用 `POST /v1/embeddings`，验证转发与 token 用量记录
- [x] 前端渠道/模型组/请求日志页面对 `openai_embedding` 协议的展示与筛选
- [x] 网关 API Key 范围限制下的请求鉴权