### PR TITLE
feat: 新增 Anthropic 与 Gemini 原生模型列表接口

### DIFF
--- a/lens_api/api/routes/proxy.py
+++ b/lens_api/api/routes/proxy.py
@@ -9,6 +9,7 @@ def register(app: FastAPI, service_module) -> None:
     app.add_api_route("/v1/embeddings", service_module.proxy_openai_embeddings, methods=["POST"])
     app.add_api_route("/v1/messages", service_module.proxy_anthropic_messages, methods=["POST"])
     app.add_api_route("/v1/models", service_module.list_gateway_models, methods=["GET"])
+    app.add_api_route("/v1beta/models", service_module.list_gemini_models, methods=["GET"])
     app.add_api_route(
         "/v1beta/models/{model_name}:generateContent",
         service_module.proxy_gemini_generate_content,

--- a/lens_api/gateway/service.py
+++ b/lens_api/gateway/service.py
@@ -1206,36 +1206,105 @@ async def proxy_openai_embeddings(
     return await _proxy_protocol(ProtocolKind.OPENAI_EMBEDDING, body, gateway_key)
 
 
-async def list_gateway_models(
-    gateway_key: GatewayApiKey = Depends(get_current_gateway_key),
-) -> dict[str, Any]:
-    groups = await app_state.domain_store.list_groups()
-    openai_model_names = sorted(
+_OPENAI_LIST_PROTOCOLS: frozenset[ProtocolKind] = frozenset(
+    {
+        ProtocolKind.OPENAI_CHAT,
+        ProtocolKind.OPENAI_RESPONSES,
+        ProtocolKind.OPENAI_EMBEDDING,
+    }
+)
+
+
+def _filtered_group_names(
+    groups: list[ModelGroup],
+    gateway_key: GatewayApiKey,
+    protocols: frozenset[ProtocolKind] | set[ProtocolKind],
+) -> list[str]:
+    return sorted(
         {
             group.name.strip()
             for group in groups
             if group.name.strip()
-            and group.protocol
-            in {
-                ProtocolKind.OPENAI_CHAT,
-                ProtocolKind.OPENAI_RESPONSES,
-                ProtocolKind.OPENAI_EMBEDDING,
-            }
+            and group.protocol in protocols
             and _gateway_key_allows_model(gateway_key, group.name)
         }
     )
+
+
+def _build_openai_models_payload(
+    groups: list[ModelGroup], gateway_key: GatewayApiKey
+) -> dict[str, Any]:
+    names = _filtered_group_names(groups, gateway_key, _OPENAI_LIST_PROTOCOLS)
     return {
         "object": "list",
         "data": [
             {
-                "id": model_name,
+                "id": name,
                 "object": "model",
                 "created": 0,
                 "owned_by": "lens",
             }
-            for model_name in openai_model_names
+            for name in names
         ],
     }
+
+
+def _build_anthropic_models_payload(
+    groups: list[ModelGroup], gateway_key: GatewayApiKey
+) -> dict[str, Any]:
+    names = _filtered_group_names(groups, gateway_key, frozenset({ProtocolKind.ANTHROPIC}))
+    return {
+        "data": [
+            {
+                "id": name,
+                "type": "model",
+                "display_name": name,
+                "created_at": "1970-01-01T00:00:00Z",
+            }
+            for name in names
+        ],
+        "first_id": names[0] if names else None,
+        "last_id": names[-1] if names else None,
+        "has_more": False,
+    }
+
+
+def _build_gemini_models_payload(
+    groups: list[ModelGroup], gateway_key: GatewayApiKey
+) -> dict[str, Any]:
+    names = _filtered_group_names(groups, gateway_key, frozenset({ProtocolKind.GEMINI}))
+    return {
+        "models": [
+            {
+                "name": f"models/{name}",
+                "baseModelId": name,
+                "version": "001",
+                "displayName": name,
+                "supportedGenerationMethods": [
+                    "generateContent",
+                    "streamGenerateContent",
+                ],
+            }
+            for name in names
+        ]
+    }
+
+
+async def list_gateway_models(
+    request: Request,
+    gateway_key: GatewayApiKey = Depends(get_current_gateway_key),
+) -> dict[str, Any]:
+    groups = await app_state.domain_store.list_groups()
+    if request.headers.get("anthropic-version"):
+        return _build_anthropic_models_payload(groups, gateway_key)
+    return _build_openai_models_payload(groups, gateway_key)
+
+
+async def list_gemini_models(
+    gateway_key: GatewayApiKey = Depends(get_current_gateway_key),
+) -> dict[str, Any]:
+    groups = await app_state.domain_store.list_groups()
+    return _build_gemini_models_payload(groups, gateway_key)
 
 
 async def proxy_gemini_generate_content(


### PR DESCRIPTION
## Summary
- `GET /v1/models` 在请求头含 `anthropic-version` 时返回 Anthropic 原生格式（`data[].type`、`display_name`、`first_id`/`last_id`/`has_more`），否则维持 OpenAI 原格式（默认行为不变）
- 新增 `GET /v1beta/models`，供 Gemini SDK 使用，字段含 `name`/`baseModelId`/`version`/`displayName`/`supportedGenerationMethods`
- 三种协议端点共享 `_gateway_key_allows_model` 过滤与 `list_groups`，对外仅暴露"模型组名称"，不返回上游 raw model 名

## Why
Anthropic Python SDK 的 `client.models.list()` 走 `GET /v1/models`，Gemini SDK 走 `GET /v1beta/models`，二者期望的字段结构与 OpenAI 不同。本 PR 让同一个 gateway key 在不同 SDK 下都能正确列出可用模型，仍受 `allowed_models` 与协议过滤约束。

## Design Notes
- Anthropic vs OpenAI 在 `/v1/models` 上靠 `anthropic-version` 头判别（Anthropic 官方 SDK 强制发此头，OpenAI SDK 不发，零误伤）
- 不改 `ModelGroup` schema：`display_name`/`displayName` fallback 至 `group.name`，`created_at` 用固定占位 `1970-01-01T00:00:00Z`，Gemini `version` 固定 `001`
- 路径冲突已验证：`/v1beta/models`（列表）与 `/v1beta/models/{model_name}:generateContent`（生成）共存无冲突

## Test plan
- [x] 本地 `lens serve` 启动后用 `curl` 验证三协议端点返回结构符合各 SDK 期望
- [x] 在已配置 Anthropic / Gemini 协议模型组的环境下回归 `client.models.list()` / `genai.list_models()`

## Out of Scope
- 不动现有 OpenAI `/v1/models` 默认行为
- 不实现 Anthropic/Gemini 列表分页（`has_more` 固定 `False`）
- 不改 UI、不改 `ModelGroup` schema