### PR TITLE
feat: 新增 Rerank 协议支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 │  /v1/messages                                                        │
 │  /v1/responses                                                       │
 │  /v1/embeddings                                                      │
+│  /v1/rerank                                                          │
 │  /v1beta/models/{model}:generateContent                              │
 │                                                                      │
 │  请求解析                                                            │
@@ -212,6 +213,7 @@ pnpm dev
 | OpenAI              | `https://api.openai.com`              | OpenAI Chat / Responses / Embeddings |
 | Anthropic           | `https://api.anthropic.com`           | Anthropic        |
 | Gemini              | `https://generativelanguage.googleapis.com` | Gemini |
+| NewAPI / Rerank     | `https://newapi.example.com`          | Rerank（透传到 `POST /v1/rerank`） |
 
 ### 2. 创建模型组
 
@@ -381,6 +383,29 @@ curl http://127.0.0.1:3000/v1/embeddings \
     "input": "hello world"
   }'
 ```
+</details>
+
+<details>
+<summary>Rerank (curl)</summary>
+
+```bash
+curl http://127.0.0.1:3000/v1/rerank \
+  -H "Authorization: Bearer sk-lens-..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "your-rerank-group",
+    "query": "What is the capital of France?",
+    "documents": [
+      "Paris is the capital of France.",
+      "Berlin is the capital of Germany.",
+      "Madrid is the capital of Spain."
+    ],
+    "top_n": 3,
+    "return_documents": true
+  }'
+```
+
+请求体透传到上游 `/v1/rerank`（如 NewAPI、Jina、Cohere 等兼容服务）。响应原样返回，包含 `results[*].relevance_score / index / document`。
 </details>
 
 <details>

--- a/README_EN.md
+++ b/README_EN.md
@@ -35,6 +35,7 @@ Self-hosted LLM gateway for managing multiple model providers.
 │  /v1/messages                                                        │
 │  /v1/responses                                                       │
 │  /v1/embeddings                                                      │
+│  /v1/rerank                                                          │
 │  /v1beta/models/{model}:generateContent                              │
 │                                                                      │
 │  Request resolution                                                  │
@@ -212,6 +213,7 @@ Common Base URLs:
 | OpenAI                    | `https://api.openai.com`              | OpenAI Chat / Responses / Embeddings |
 | Anthropic                 | `https://api.anthropic.com`           | Anthropic        |
 | Gemini                    | `https://generativelanguage.googleapis.com` | Gemini |
+| NewAPI / Rerank           | `https://newapi.example.com`          | Rerank (forwards to `POST /v1/rerank`) |
 
 ### 2. Create Model Groups
 
@@ -381,6 +383,29 @@ curl http://127.0.0.1:3000/v1/embeddings \
     "input": "hello world"
   }'
 ```
+</details>
+
+<details>
+<summary>Rerank (curl)</summary>
+
+```bash
+curl http://127.0.0.1:3000/v1/rerank \
+  -H "Authorization: Bearer sk-lens-..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "your-rerank-group",
+    "query": "What is the capital of France?",
+    "documents": [
+      "Paris is the capital of France.",
+      "Berlin is the capital of Germany.",
+      "Madrid is the capital of Spain."
+    ],
+    "top_n": 3,
+    "return_documents": true
+  }'
+```
+
+The request body is forwarded as-is to the upstream `/v1/rerank` endpoint (e.g. NewAPI, Jina, Cohere-compatible services). Responses are returned unmodified, including `results[*].relevance_score / index / document`.
 </details>
 
 <details>

--- a/lens_api/api/routes/proxy.py
+++ b/lens_api/api/routes/proxy.py
@@ -13,6 +13,7 @@ def register(app: FastAPI, service_module: ModuleType) -> None:
     app.add_api_route(
         "/v1/embeddings", service_module.proxy_openai_embeddings, methods=["POST"]
     )
+    app.add_api_route("/v1/rerank", service_module.proxy_rerank, methods=["POST"])
     app.add_api_route(
         "/v1/messages", service_module.proxy_anthropic_messages, methods=["POST"]
     )

--- a/lens_api/gateway/service.py
+++ b/lens_api/gateway/service.py
@@ -2729,7 +2729,10 @@ def _apply_model_test_param_override(
             credential_id=payload.credential.id,
             error_message=_format_channel_error(exc.detail),
         )
-    prepared_body["stream"] = False
+    if payload.protocol == ProtocolKind.RERANK:
+        prepared_body.pop("stream", None)
+    else:
+        prepared_body["stream"] = False
     return prepared_body
 
 

--- a/lens_api/gateway/service.py
+++ b/lens_api/gateway/service.py
@@ -1493,11 +1493,30 @@ async def proxy_openai_embeddings(
     )
 
 
+async def proxy_rerank(
+    request: Request, gateway_key: GatewayApiKey = Depends(get_current_gateway_key)
+):
+    body = await request.json()
+    if not isinstance(body, dict):
+        raise HTTPException(
+            status_code=400,
+            detail="Rerank request body must be a JSON object",
+        )
+    body.pop("stream", None)
+    return await _proxy_protocol(
+        ProtocolKind.RERANK,
+        body,
+        gateway_key,
+        request.headers.get("user-agent"),
+    )
+
+
 _OPENAI_LIST_PROTOCOLS: frozenset[ProtocolKind] = frozenset(
     {
         ProtocolKind.OPENAI_CHAT,
         ProtocolKind.OPENAI_RESPONSES,
         ProtocolKind.OPENAI_EMBEDDING,
+        ProtocolKind.RERANK,
     }
 )
 _ALL_MODEL_LIST_PROTOCOLS: frozenset[ProtocolKind] = frozenset(ProtocolKind)
@@ -1992,7 +2011,7 @@ async def _try_target(
             upstream_body=upstream_body,
             exc=exc,
         )
-    if protocol == ProtocolKind.OPENAI_EMBEDDING:
+    if protocol in {ProtocolKind.OPENAI_EMBEDDING, ProtocolKind.RERANK}:
         upstream_body.pop("stream", None)
 
     upstream_request_content = _dump_json(upstream_body)
@@ -2611,6 +2630,8 @@ def _model_test_output_text(protocol: ProtocolKind, raw_payload: Any) -> str:
                 if isinstance(vector, str) and vector:
                     output_text = f"<vector base64 len={len(vector)}>"
                     break
+    elif protocol == ProtocolKind.RERANK:
+        output_text = _summarize_rerank_result(raw_payload)
     elif protocol == ProtocolKind.ANTHROPIC:
         content = raw_payload.get("content")
         if isinstance(content, list):
@@ -2666,6 +2687,15 @@ def _model_test_body(payload: SiteModelTestRequest) -> dict[str, Any]:
             "model": payload.model_name,
             "input": text,
         }
+    if payload.protocol == ProtocolKind.RERANK:
+        query, documents = _rerank_test_prompt(text)
+        return {
+            "model": payload.model_name,
+            "query": query,
+            "documents": documents,
+            "top_n": min(3, len(documents)),
+            "return_documents": True,
+        }
     if payload.protocol == ProtocolKind.ANTHROPIC:
         return {
             "model": payload.model_name,
@@ -2701,6 +2731,57 @@ def _apply_model_test_param_override(
         )
     prepared_body["stream"] = False
     return prepared_body
+
+
+def _summarize_rerank_result(payload: Any) -> str:
+    if not isinstance(payload, dict):
+        return ""
+    results = payload.get("results")
+    if not isinstance(results, list) or not results:
+        return ""
+    top = max(
+        (item for item in results if isinstance(item, dict)),
+        key=lambda item: _coerce_relevance_score(item.get("relevance_score")),
+        default=None,
+    )
+    if top is None:
+        return ""
+    score = _coerce_relevance_score(top.get("relevance_score"))
+    index = top.get("index")
+    document = top.get("document")
+    document_text = ""
+    if isinstance(document, dict):
+        text_value = document.get("text")
+        if isinstance(text_value, str):
+            document_text = text_value
+    elif isinstance(document, str):
+        document_text = document
+    snippet = document_text.strip().replace("\n", " ")
+    if len(snippet) > 120:
+        snippet = snippet[:117] + "..."
+    parts: list[str] = [f"top score={score:.4f}"]
+    if isinstance(index, int):
+        parts.append(f"index={index}")
+    if snippet:
+        parts.append(f"document={snippet}")
+    return "; ".join(parts)
+
+
+def _coerce_relevance_score(value: Any) -> float:
+    try:
+        if value is None:
+            return float("-inf")
+        return float(value)
+    except (TypeError, ValueError):
+        return float("-inf")
+
+
+def _rerank_test_prompt(text: str) -> tuple[str, list[str]]:
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    if len(lines) >= 2:
+        return lines[0], lines[1:]
+    query = lines[0] if lines else text.strip()
+    return query, [query]
 
 
 def _stringify_text_content(value: Any) -> str:
@@ -2820,6 +2901,7 @@ def _model_list_request(channel: ChannelConfig) -> dict[str, Any]:
         ProtocolKind.OPENAI_CHAT,
         ProtocolKind.OPENAI_RESPONSES,
         ProtocolKind.OPENAI_EMBEDDING,
+        ProtocolKind.RERANK,
     }:
         return {
             "method": "GET",
@@ -3788,7 +3870,11 @@ def _extract_stream_usage(
     raw_content: str | None,
     parse_errors: list[str] | None = None,
 ) -> dict[str, int | str | None]:
-    if protocol == ProtocolKind.OPENAI_EMBEDDING or not raw_content:
+    if (
+        protocol == ProtocolKind.OPENAI_EMBEDDING
+        or protocol == ProtocolKind.RERANK
+        or not raw_content
+    ):
         return dict(_EMPTY_USAGE)
 
     if protocol == ProtocolKind.GEMINI:
@@ -3929,6 +4015,17 @@ def _extract_usage_from_payload(
 def _extract_response_usage(
     protocol: ProtocolKind, response: httpx.Response
 ) -> dict[str, int | str | None]:
+    if protocol == ProtocolKind.RERANK:
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = None
+        empty = dict(_EMPTY_USAGE)
+        if isinstance(payload, dict):
+            model_value = payload.get("model")
+            if isinstance(model_value, str) and model_value.strip():
+                empty["resolved_model"] = model_value
+        return empty
     payload = response.json()
     if not isinstance(payload, dict):
         raise ValueError("Upstream response JSON must be an object")

--- a/lens_api/gateway/upstreams.py
+++ b/lens_api/gateway/upstreams.py
@@ -21,6 +21,7 @@ _OPENAI_LIKE_PATH = {
     ProtocolKind.OPENAI_CHAT: "chat/completions",
     ProtocolKind.OPENAI_RESPONSES: "responses",
     ProtocolKind.OPENAI_EMBEDDING: "embeddings",
+    ProtocolKind.RERANK: "rerank",
     ProtocolKind.ANTHROPIC: "messages",
 }
 
@@ -115,6 +116,7 @@ def _protocol_base_url(channel: ChannelConfig) -> str:
         ProtocolKind.OPENAI_CHAT,
         ProtocolKind.OPENAI_RESPONSES,
         ProtocolKind.OPENAI_EMBEDDING,
+        ProtocolKind.RERANK,
         ProtocolKind.ANTHROPIC,
     }:
         return _append_url_path(root, "v1")

--- a/lens_api/models.py
+++ b/lens_api/models.py
@@ -83,6 +83,7 @@ class ProtocolKind(str, Enum):
     OPENAI_CHAT = "openai_chat"
     OPENAI_RESPONSES = "openai_responses"
     OPENAI_EMBEDDING = "openai_embedding"
+    RERANK = "rerank"
     ANTHROPIC = "anthropic"
     GEMINI = "gemini"
 

--- a/ui/src/components/screens/channels-screen.tsx
+++ b/ui/src/components/screens/channels-screen.tsx
@@ -83,6 +83,7 @@ const protocolOptions: Array<{ value: ProtocolKind; label: string }> = [
   { value: "openai_chat", label: "OpenAI Chat" },
   { value: "openai_responses", label: "OpenAI Responses" },
   { value: "openai_embedding", label: "OpenAI Embedding" },
+  { value: "rerank", label: "Rerank" },
   { value: "anthropic", label: "Anthropic" },
   { value: "gemini", label: "Gemini" },
 ];
@@ -200,6 +201,8 @@ function compactProtocolLabel(protocol: ProtocolKind) {
       return "responses";
     case "openai_embedding":
       return "embeddings";
+    case "rerank":
+      return "rerank";
     case "anthropic":
       return "anthropic";
     case "gemini":
@@ -368,6 +371,8 @@ function protocolBadgeClassName(protocol: ProtocolKind) {
       return "border-transparent bg-indigo-500/10 text-indigo-700";
     case "openai_embedding":
       return "border-transparent bg-cyan-500/10 text-cyan-700";
+    case "rerank":
+      return "border-transparent bg-violet-500/10 text-violet-700";
     case "anthropic":
       return "border-transparent bg-amber-500/10 text-amber-700";
     case "gemini":
@@ -1686,6 +1691,13 @@ function ModelTestDialog({
                         value={modelTestPrompt}
                         onChange={(event) => onPromptChange(event.target.value)}
                       />
+                      {protocol?.protocol === "rerank" ? (
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {locale === "zh-CN"
+                            ? "Rerank 测试：首行为查询，其余行作为候选文档（每行一个）。"
+                            : "Rerank test: first line is the query, remaining lines are candidate documents (one per line)."}
+                        </p>
+                      ) : null}
                     </Field>
                   </div>
 

--- a/ui/src/components/screens/groups-screen.tsx
+++ b/ui/src/components/screens/groups-screen.tsx
@@ -212,6 +212,7 @@ const protocolLabels: Record<ProtocolKind, { zh: string; en: string }> = {
   openai_chat: { zh: "OpenAI Chat", en: "OpenAI Chat" },
   openai_responses: { zh: "OpenAI Responses", en: "OpenAI Responses" },
   openai_embedding: { zh: "OpenAI Embedding", en: "OpenAI Embedding" },
+  rerank: { zh: "Rerank", en: "Rerank" },
   anthropic: { zh: "Anthropic", en: "Anthropic" },
   gemini: { zh: "Gemini", en: "Gemini" },
 };
@@ -252,6 +253,8 @@ function protocolBadgeClassName(protocol: ProtocolKind) {
       return "border-transparent bg-indigo-500/10 text-indigo-700";
     case "openai_embedding":
       return "border-transparent bg-cyan-500/10 text-cyan-700";
+    case "rerank":
+      return "border-transparent bg-violet-500/10 text-violet-700";
     case "anthropic":
       return "border-transparent bg-amber-500/10 text-amber-700";
     case "gemini":

--- a/ui/src/components/screens/requests-screen.tsx
+++ b/ui/src/components/screens/requests-screen.tsx
@@ -369,6 +369,7 @@ function ProtocolBadge({ protocol }: { protocol: RequestLogItem["protocol"] }) {
     openai_chat: "chat",
     openai_responses: "responses",
     openai_embedding: "embedding",
+    rerank: "rerank",
     anthropic: "anthropic",
     gemini: "gemini",
   } as const;
@@ -1560,6 +1561,9 @@ export function RequestsScreen() {
                         </NativeSelectOption>
                         <NativeSelectOption value="openai_embedding">
                           OpenAI Embedding
+                        </NativeSelectOption>
+                        <NativeSelectOption value="rerank">
+                          Rerank
                         </NativeSelectOption>
                         <NativeSelectOption value="anthropic">
                           Anthropic

--- a/ui/src/components/settings/gateway-api-key-manager.tsx
+++ b/ui/src/components/settings/gateway-api-key-manager.tsx
@@ -93,6 +93,7 @@ const PROTOCOL_LABELS: Record<ProtocolKind, [string, string]> = {
   openai_chat: ["OpenAI Chat", "OpenAI Chat"],
   openai_responses: ["OpenAI Responses", "OpenAI Responses"],
   openai_embedding: ["OpenAI Embedding", "OpenAI Embedding"],
+  rerank: ["Rerank", "Rerank"],
   anthropic: ["Anthropic", "Anthropic"],
   gemini: ["Gemini", "Gemini"],
 };

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -4,6 +4,7 @@ export type ProtocolKind =
   | "openai_chat"
   | "openai_responses"
   | "openai_embedding"
+  | "rerank"
   | "anthropic"
   | "gemini";
 

--- a/ui/src/lib/i18n.tsx
+++ b/ui/src/lib/i18n.tsx
@@ -29,7 +29,7 @@ const messages: Record<Locale, Copy> = {
   "zh-CN": {
     loginTitle: "统一管理渠道、模型组与系统配置",
     loginSubtitle:
-      "OpenAI Chat / OpenAI Responses / OpenAI Embedding / Anthropic / Gemini",
+      "OpenAI Chat / OpenAI Responses / OpenAI Embedding / Rerank / Anthropic / Gemini",
     username: "用户名",
     password: "密码",
     signIn: "登录",
@@ -50,7 +50,7 @@ const messages: Record<Locale, Copy> = {
   "en-US": {
     loginTitle: "Manage channels, model groups, and system settings",
     loginSubtitle:
-      "OpenAI Chat / OpenAI Responses / OpenAI Embedding / Anthropic / Gemini",
+      "OpenAI Chat / OpenAI Responses / OpenAI Embedding / Rerank / Anthropic / Gemini",
     username: "Username",
     password: "Password",
     signIn: "Sign in",


### PR DESCRIPTION
## 摘要

- 新增 `POST /v1/rerank` 网关入口，将 Rerank 请求透传至兼容上游。
- 在渠道、模型组、请求日志与 API Key 管理界面中加入 Rerank 协议支持。
- 补充中英文 README 的 Rerank 配置与调用示例。
- 修复 Rerank 模型测试请求错误携带 `stream` 参数的问题。

## 影响

- 用户可配置 Rerank 上游，并通过 Lens 统一路由调用。
- Rerank 仅进行同协议路由，不加入现有 Chat / Anthropic / Responses 转换链路。
- 当前 Rerank 请求日志中的 token 与成本统计保持为 `0`。

## 验证

- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `python -m lens_api.cli db upgrade`
- `python -m alembic check`
- `python -m lens_api.cli db current`
- Rerank 路由注册、上游 URL/鉴权转发及模型测试请求体烟测
- `git merge-tree` 验证目标分支合并无冲突
